### PR TITLE
Fix the bug uninitailized variable 'ncats' in  smk_set_cipso() function

### DIFF
--- a/security/smack/smackfs.c
+++ b/security/smack/smackfs.c
@@ -935,7 +935,8 @@ static ssize_t smk_set_cipso(struct file *file, const char __user *buf,
 
 		smack_catset_bit(cat, mapcatset);
 	}
-
+	memset(&ncats, 0, sizeof(ncats));
+	
 	rc = smk_netlbl_mls(maplevel, mapcatset, &ncats, SMK_CIPSOLEN);
 	if (rc >= 0) {
 		netlbl_catmap_free(skp->smk_netlabel.attr.mls.cat);


### PR DESCRIPTION
Fix the bug uninitailized variable 'ncats' in
 smk_set_cipso() function

In smk_set_cipso() function,'ncats' variable is passed to
"smk_netlbl_mls()" function without being initialized. While in
"smk_netlbl_mls()" function, "ncats->flags' is used to update
the flags value using '|' operation.
So 'ncats' is initialized to 0 using memset to prevent any wrong value
assignment to 'ncats->flags'