### PR TITLE
This patch adds the rcu synchronization mechanism in SMACK  IPv6 hooks

### DIFF
--- a/security/smack/smack.h
+++ b/security/smack/smack.h
@@ -167,6 +167,7 @@ struct smk_port_label {
 	unsigned short		smk_port;	/* the port number */
 	struct smack_known	*smk_in;	/* inbound label */
 	struct smack_known	*smk_out;	/* outgoing label */
+	short                   sock_type;      /*Socket type*/
 };
 #endif /* SMACK_IPV6_PORT_LABELING */
 

--- a/security/smack/smack_lsm.c
+++ b/security/smack/smack_lsm.c
@@ -52,6 +52,7 @@
 #define SMK_SENDING	2
 
 #ifdef SMACK_IPV6_PORT_LABELING
+DEFINE_MUTEX(smack_ipv6_lock);
 static LIST_HEAD(smk_ipv6_port_list);
 #endif
 static struct kmem_cache *smack_inode_cache;
@@ -2559,17 +2560,20 @@ static void smk_ipv6_port_label(struct socket *sock, struct sockaddr *address)
 		 * on the bound socket. Take the changes to the port
 		 * as well.
 		 */
-		list_for_each_entry(spp, &smk_ipv6_port_list, list) {
+		rcu_read_lock();
+		list_for_each_entry_rcu(spp, &smk_ipv6_port_list, list) {
 			if (sk != spp->smk_sock)
 				continue;
 			spp->smk_in = ssp->smk_in;
 			spp->smk_out = ssp->smk_out;
+			rcu_read_unlock();
 			return;
 		}
 		/*
 		 * A NULL address is only used for updating existing
 		 * bound entries. If there isn't one, it's OK.
 		 */
+		rcu_read_unlock();
 		return;
 	}
 
@@ -2585,16 +2589,18 @@ static void smk_ipv6_port_label(struct socket *sock, struct sockaddr *address)
 	 * Look for an existing port list entry.
 	 * This is an indication that a port is getting reused.
 	 */
-	list_for_each_entry(spp, &smk_ipv6_port_list, list) {
+	rcu_read_lock();
+	list_for_each_entry_rcu(spp, &smk_ipv6_port_list, list) {
 		if (spp->smk_port != port)
 			continue;
 		spp->smk_port = port;
 		spp->smk_sock = sk;
 		spp->smk_in = ssp->smk_in;
 		spp->smk_out = ssp->smk_out;
+		rcu_read_unlock();
 		return;
 	}
-
+	rcu_read_unlock();
 	/*
 	 * A new port entry is required.
 	 */
@@ -2607,7 +2613,9 @@ static void smk_ipv6_port_label(struct socket *sock, struct sockaddr *address)
 	spp->smk_in = ssp->smk_in;
 	spp->smk_out = ssp->smk_out;
 
-	list_add(&spp->list, &smk_ipv6_port_list);
+	mutex_lock(&smack_ipv6_lock);
+	list_add_rcu(&spp->list, &smk_ipv6_port_list);
+	mutex_unlock(&smack_ipv6_lock);
 	return;
 }
 
@@ -2658,7 +2666,8 @@ static int smk_ipv6_port_check(struct sock *sk, struct sockaddr_in6 *address,
 		return 0;
 
 	port = ntohs(address->sin6_port);
-	list_for_each_entry(spp, &smk_ipv6_port_list, list) {
+	rcu_read_lock();
+	list_for_each_entry_rcu(spp, &smk_ipv6_port_list, list) {
 		if (spp->smk_port != port)
 			continue;
 		object = spp->smk_in;
@@ -2666,7 +2675,8 @@ static int smk_ipv6_port_check(struct sock *sk, struct sockaddr_in6 *address,
 			ssp->smk_packet = spp->smk_out;
 		break;
 	}
-
+	rcu_read_unlock();
+	
 	return smk_ipv6_check(skp, object, address, act);
 }
 #endif /* SMACK_IPV6_PORT_LABELING */

--- a/security/smack/smack_lsm.c
+++ b/security/smack/smack_lsm.c
@@ -2591,7 +2591,7 @@ static void smk_ipv6_port_label(struct socket *sock, struct sockaddr *address)
 	 */
 	rcu_read_lock();
 	list_for_each_entry_rcu(spp, &smk_ipv6_port_list, list) {
-		if (spp->smk_port != port)
+		if (spp->smk_port != port || spp->sock_type != sock->type)
 			continue;
 		spp->smk_port = port;
 		spp->smk_sock = sk;
@@ -2612,6 +2612,7 @@ static void smk_ipv6_port_label(struct socket *sock, struct sockaddr *address)
 	spp->smk_sock = sk;
 	spp->smk_in = ssp->smk_in;
 	spp->smk_out = ssp->smk_out;
+	spp->sock_type = sock->type;
 
 	mutex_lock(&smack_ipv6_lock);
 	list_add_rcu(&spp->list, &smk_ipv6_port_list);
@@ -2668,7 +2669,7 @@ static int smk_ipv6_port_check(struct sock *sk, struct sockaddr_in6 *address,
 	port = ntohs(address->sin6_port);
 	rcu_read_lock();
 	list_for_each_entry_rcu(spp, &smk_ipv6_port_list, list) {
-		if (spp->smk_port != port)
+		if (spp->smk_port != port || spp->sock_type != sk->sk_type)
 			continue;
 		object = spp->smk_in;
 		if (act == SMK_CONNECTING)


### PR DESCRIPTION
This patch adds the rcu synchronization mechanism in SMACK
 IPv6 hooks while accessing smk_ipv6_port_list. Access to the port list is
 vulnerable to a race condition issue, it does not apply proper
 synchronization methods while working on critical section. It is possible
 that when one thread is reading the list, at the same time another thread is
 modifying the same port list, which can cause the major problems. To ensure
 proper synchronization between two threads, rcu mechanism has been applied
 while accessing and modifying the port list. RCU will also not affect the
 performance as in access control module there are more accesses than
 modification where RCU is most effective synchronization mechanism.

Changelist Id:-6b69430a8631deaaa05fc885a4f28b78bf786c27

Signed-off-by: Vishal Goel vishal.goel@samsung.com
Signed-off-by: Himanshu Shukla himanshu.sh@samsung.com
