### PR TITLE
This patch fixes the undesired SMACK label (SMACK64IPIN)  update

### DIFF
--- a/security/smack/smack.h
+++ b/security/smack/smack.h
@@ -167,6 +167,7 @@ struct smk_port_label {
 	unsigned short		smk_port;	/* the port number */
 	struct smack_known	*smk_in;	/* inbound label */
 	struct smack_known	*smk_out;	/* outgoing label */
+	short                   smk_can_reuse;
 };
 #endif /* SMACK_IPV6_PORT_LABELING */
 


### PR DESCRIPTION
This patch fixes the undesired SMACK label (SMACK64IPIN)
 update when a second bind call is made to same IP address & port, but with
 different SMACK label (SMACK64IPIN) by second instance of server. In this
 case server returns with "Bind:Address already in use" error but before
 returning, SMACK label is updated in SMACK port-label mapping list inside
 "smack_socket_bind()" hook.

To fix the issue a new check has been added in smk_ipv6_port_label() function
before updating the existing port entry. It checks whether the socket for corresponding
port entry is closed or not. If it is closed then it means port is not bound and it is
safe to update the existing port entry else return if port is still getting used.
For checking whether socket is closed or not, one more field "smk_can_reuse" has been
added in the "smk_port_label" structure. This field will be set to '1' in "smack_sk_free_security()"
function which is called to free the socket security blob when the socket is being closed.
In this function, port entry is searched in the SMACK port-label mapping list for the closing socket.
If entry is found then "smk_can_reuse" field is set to '1'.Initially "smk_can_reuse" field is
set to '0' in smk_ipv6_port_label() function after creating a new entry in the list which
indicates that socket is in use.

Changelist id:- 7691868d9f8615d97d90794de1e06970f8575c48
Signed-off-by: Vishal Goel vishal.goel@samsung.com
Signed-off-by: Himanshu Shukla himanshu.sh@samsung.com
