### PR TITLE
Smack: Improve documentation

### DIFF
--- a/Documentation/admin-guide/LSM/Smack.rst
+++ b/Documentation/admin-guide/LSM/Smack.rst
@@ -818,6 +818,10 @@ Smack supports some mount options:
 	specifies a label to which all labels set on the
 	filesystem must have read access. Not yet enforced.
 
+  smackfstransmute=label:
+        behaves exactly like smackfsroot except that it also
+        set the transmuting flag on the root of the mount
+
 These mount options apply to all file system types.
 
 Smack auditing


### PR DESCRIPTION
Add some words about the mount option "smackfstransmute=label".

Signed-off-by: José Bollo <jobol@nonadev.net>